### PR TITLE
Add gpt-4o and variants of it to ModelToEncodingMapping

### DIFF
--- a/SharpToken/Lib/Model.cs
+++ b/SharpToken/Lib/Model.cs
@@ -9,6 +9,7 @@ namespace SharpToken
         {
             // chat
             { "gpt-4", "cl100k_base" },
+            { "gpt-4o", "cl100k_base" },
             { "gpt-3.5-turbo-16k", "cl100k_base" },
             { "gpt-35-turbo-16k", "cl100k_base" }, // Azure deployment name
             { "gpt-3.5-turbo", "cl100k_base" },
@@ -54,6 +55,7 @@ namespace SharpToken
         private static readonly Dictionary<string, string> ModelPrefixToEncodingMapping = new Dictionary<string, string>
         {
             { "gpt-4-", "cl100k_base" }, // e.g., gpt-4-0314, etc., plus gpt-4-32k
+            { "gpt-4o-", "cl100k_base" }, // e.g., gpt-4o-2024-05-13
             { "gpt-3.5-turbo-", "cl100k_base" }, // e.g, gpt-3.5-turbo-0301, -0401, etc.
             { "gpt-35-turbo", "cl100k_base" }, // Azure deployment name
         };


### PR DESCRIPTION
The new GPT-4o model was introduced on 2024-05-13 at the OpenAI spring event